### PR TITLE
Add customizable fast shoot message

### DIFF
--- a/maps/MP/gametypes/_pam_sd.gsc
+++ b/maps/MP/gametypes/_pam_sd.gsc
@@ -572,9 +572,9 @@ rFASHSHOOTmessage()
 			}
 
 			self.rFASHSHOOTmessage++;
-			self iprintln("^1~^3empire ^2| ^1automod: ^3" + self.name + " ^1used fastshooting!^3 (" + self.rFASHSHOOTmessage + ")");
-		}
-	}
+                        self iprintln(getcvar("ui_AutoAdmin_FastShootMsg") + self.name + " ^1used fastshooting!^3 (" + self.rFASHSHOOTmessage + ")");
+                }
+        }
 }
 
 rSTRATEXPLOIT()

--- a/maps/MP/gametypes/_teams.gsc
+++ b/maps/MP/gametypes/_teams.gsc
@@ -635,14 +635,20 @@ initGlobalCvars()
 	setCvar("ui_AutoAdmin_AFK_NotifyActionTaken", level.ui_AutoAdmin_AFK_NotifyActionTaken);
 	makeCvarServerInfo("ui_AutoAdmin_AFK_NotifyActionTaken", "^1~^3empire ^2| ^1automod: ^3You have been forced into spectator mode due to ^1AFK^3 behavior.");
 
-	level.ui_AutoAdmin_AFK_NotifyRemoved = getCvar("ui_AutoAdmin_AFK_NotifyRemoved");
-	if(level.ui_AutoAdmin_AFK_NotifyRemoved == "")
-		level.ui_AutoAdmin_AFK_NotifyRemoved = "^1~^3empire ^2| ^1automod: ^3You are no longer marked as ^1AFK^3.";
-	setCvar("ui_AutoAdmin_AFK_NotifyRemoved", level.ui_AutoAdmin_AFK_NotifyRemoved);
-	makeCvarServerInfo("ui_AutoAdmin_AFK_NotifyRemoved", "^1~^3empire ^2| ^1automod: ^3You are no longer marked as ^1AFK^3.");
+        level.ui_AutoAdmin_AFK_NotifyRemoved = getCvar("ui_AutoAdmin_AFK_NotifyRemoved");
+        if(level.ui_AutoAdmin_AFK_NotifyRemoved == "")
+                level.ui_AutoAdmin_AFK_NotifyRemoved = "^1~^3empire ^2| ^1automod: ^3You are no longer marked as ^1AFK^3.";
+        setCvar("ui_AutoAdmin_AFK_NotifyRemoved", level.ui_AutoAdmin_AFK_NotifyRemoved);
+        makeCvarServerInfo("ui_AutoAdmin_AFK_NotifyRemoved", "^1~^3empire ^2| ^1automod: ^3You are no longer marked as ^1AFK^3.");
 
-	// Initialize g_allowedGametypeVote cvar
-	level.allowedGametypeVote = getCvar("g_allowedGametypeVote");
+        level.ui_AutoAdmin_FastShootMsg = getCvar("ui_AutoAdmin_FastShootMsg");
+        if(level.ui_AutoAdmin_FastShootMsg == "")
+                level.ui_AutoAdmin_FastShootMsg = "^1~^3empire ^2| ^1automod: ^3";
+        setCvar("ui_AutoAdmin_FastShootMsg", level.ui_AutoAdmin_FastShootMsg);
+        makeCvarServerInfo("ui_AutoAdmin_FastShootMsg", "^1~^3empire ^2| ^1automod: ^3");
+
+        // Initialize g_allowedGametypeVote cvar
+        level.allowedGametypeVote = getCvar("g_allowedGametypeVote");
 	if(level.allowedGametypeVote == "")
 		level.allowedGametypeVote = "dm tdm sd"; // Default allowed gametypes
 	setCvar("g_allowedGametypeVote", level.allowedGametypeVote);
@@ -1008,10 +1014,15 @@ updateGlobalCvars()
 			setCvar("ui_AutoAdmin_AFK_NotifyActionTaken", level.ui_AutoAdmin_AFK_NotifyActionTaken);
 		}
 
-		if(level.ui_AutoAdmin_AFK_NotifyRemoved != getCvar("ui_AutoAdmin_AFK_NotifyRemoved")) {
-			level.ui_AutoAdmin_AFK_NotifyRemoved = getCvar("ui_AutoAdmin_AFK_NotifyRemoved");
-			setCvar("ui_AutoAdmin_AFK_NotifyRemoved", level.ui_AutoAdmin_AFK_NotifyRemoved);
-		}
+                if(level.ui_AutoAdmin_AFK_NotifyRemoved != getCvar("ui_AutoAdmin_AFK_NotifyRemoved")) {
+                        level.ui_AutoAdmin_AFK_NotifyRemoved = getCvar("ui_AutoAdmin_AFK_NotifyRemoved");
+                        setCvar("ui_AutoAdmin_AFK_NotifyRemoved", level.ui_AutoAdmin_AFK_NotifyRemoved);
+                }
+
+                if(level.ui_AutoAdmin_FastShootMsg != getCvar("ui_AutoAdmin_FastShootMsg")) {
+                        level.ui_AutoAdmin_FastShootMsg = getCvar("ui_AutoAdmin_FastShootMsg");
+                        setCvar("ui_AutoAdmin_FastShootMsg", level.ui_AutoAdmin_FastShootMsg);
+                }
 
 		// Monitor changes to g_allowedGametypeVote
 		allowedGametypeVote = getCvar("g_allowedGametypeVote");

--- a/the_empire_mod.txt
+++ b/the_empire_mod.txt
@@ -23,6 +23,7 @@ ui_AutoAdmin_AFK_NotifyPlayer "^1~^3empire ^2| ^1automod: ^3You have been detect
 ui_AutoAdmin_AFK_NotifyPublic " has been detected as AFK and will be forced into spectator mode in "
 ui_AutoAdmin_AFK_NotifyActionTaken "^1~^3empire ^2| ^1automod: ^3You have been forced into spectator mode due to ^1AFK^3 behavior."
 ui_AutoAdmin_AFK_NotifyRemoved "^1~^3empire ^2| ^1automod: ^3You are no longer marked as ^1AFK^3."
+ui_AutoAdmin_FastShootMsg "^1~^3empire ^2| ^1automod: ^3"
 
 // Allowed gametype voting
 g_allowedGametypeVote "ctf sd dm tdm bas re hq dom bel" // space delimited list of gametypes that can be voted


### PR DESCRIPTION
## Summary
- add `ui_AutoAdmin_FastShootMsg` cvar for fast shooting notices
- initialize the new cvar in `_teams.gsc`
- monitor cvar for updates in `_teams.gsc`
- use the cvar in `_pam_sd.gsc` instead of a hardcoded prefix

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684da82aa9cc8329a7deb8487c77606d