### PR TITLE
Skip AFK checks for flag carriers

### DIFF
--- a/maps/MP/gametypes/_awe.gsc
+++ b/maps/MP/gametypes/_awe.gsc
@@ -4868,21 +4868,25 @@ monitorme()
 			//iprintln("DEBUG: Movement not detected, pace=" + self.awe_pace);
 			}
 
-		if(level.awe_anticamptime && !isdefined(self.awe_camper) && !isdefined(level.awe_tdom))
-		{
-			// Check for campers
-			if(self.awe_pace == 0) {
-				count++;
-			} else {
-				count=0;
-				//self notify("not_afk");
-			}
-			if(count>=level.awe_anticamptime)
-			{
-				self thread camper();
-				count=0;
-			}
-		}
+                if(level.awe_anticamptime && !isdefined(self.awe_camper) && !isdefined(level.awe_tdom) && !isdefined(self.hasflag) && (!isdefined(self.carrying) || !self.carrying))
+                {
+                        // Check for campers
+                        if(self.awe_pace == 0)
+                        {
+                                count++;
+                        }
+                        else
+                        {
+                                count = 0;
+                                //self notify("not_afk");
+                        }
+
+                        if(count >= level.awe_anticamptime)
+                        {
+                                self thread camper();
+                                count = 0;
+                        }
+                }
 
 		// Mess with the poor camper
 		if(level.awe_anticampfun && isdefined(self.awe_camper))
@@ -4921,6 +4925,10 @@ camper()
 {
     self endon("awe_spawned");
     self endon("not_afk");
+
+    // Skip AFK handling if the player is carrying a flag/object
+    if(isdefined(self.hasflag) || (isdefined(self.carrying) && self.carrying))
+        return;
         
     // Ensure any previous timer is cleared.
     if(isdefined(self.awe_camptimer))


### PR DESCRIPTION
## Summary
- ensure `monitorme` ignores campers when a flag or object is being carried
- exit `camper()` immediately for active flag carriers

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684dadeadbdc83298c4f2a3e7783a419