### PR TITLE
Add server logo text CVAR

### DIFF
--- a/maps/MP/gametypes/_awe.gsc
+++ b/maps/MP/gametypes/_awe.gsc
@@ -749,8 +749,13 @@ setupVariables()
 		level.awe_logotext = &"^6AWE ^52.1";
 	}
 
-	if(level.awe_showserverlogo)
-		server_logo\_awe_server_logo::logo();
+       if(level.awe_showserverlogo)
+       {
+               if(level.awe_server_logo_text != "")
+                       level.awe_serverlogotext = &level.awe_server_logo_text;
+               else
+                       server_logo\_awe_server_logo::logo();
+       }
 }
 
 awePrecacheShader(shader)
@@ -2391,8 +2396,9 @@ updateGametypeCvars(init)
 
 		// Hud
 		level.awe_showlogo = cvardef("awe_show_logo", 1, 0, 1, "int");	
-		level.awe_showserverlogo = cvardef("awe_show_server_logo", 0, 0, 2, "int");	
-		level.awe_showsdtimer_cvar = cvardef("awe_show_sd_timer", 0, 0, 1, "int");	
+               level.awe_showserverlogo = cvardef("awe_show_server_logo", 0, 0, 2, "int");
+               level.awe_server_logo_text = cvardef("awe_server_logo_text", "", "", "", "string");
+               level.awe_showsdtimer_cvar = cvardef("awe_show_sd_timer", 0, 0, 1, "int");
 		if(level.awe_showsdtimer_cvar)
 			level.awe_showsdtimer = true;
 		else

--- a/maps/MP/gametypes/_teams.gsc
+++ b/maps/MP/gametypes/_teams.gsc
@@ -613,8 +613,14 @@ initGlobalCvars()
 	level.ui_BrandGametypeEnabled = getCvar("ui_BrandGametypeEnabled");
 	if(level.ui_BrandGametypeEnabled == "")
 		level.ui_BrandGametypeEnabled = "1";
-	setCvar("ui_BrandGametypeEnabled", level.ui_BrandGametypeEnabled);
-	makeCvarServerInfo("ui_BrandGametypeEnabled", "1");
+        setCvar("ui_BrandGametypeEnabled", level.ui_BrandGametypeEnabled);
+        makeCvarServerInfo("ui_BrandGametypeEnabled", "1");
+
+        level.awe_server_logo_text = getCvar("awe_server_logo_text");
+        if(level.awe_server_logo_text == "")
+                level.awe_server_logo_text = "";
+        setCvar("awe_server_logo_text", level.awe_server_logo_text);
+        makeCvarServerInfo("awe_server_logo_text", "");
 
 	// AutoAdmin
 	level.ui_AutoAdmin_AFK_NotifyPlayer = getCvar("ui_AutoAdmin_AFK_NotifyPlayer");
@@ -994,10 +1000,16 @@ updateGlobalCvars()
 			setCvar("ui_BrandNextMap", level.ui_BrandNextMap);
 		}
 
-		if(level.ui_BrandGametypeEnabled != getCvar("ui_BrandGametypeEnabled")) {
-			level.ui_BrandGametypeEnabled = getCvar("ui_BrandGametypeEnabled");
-			setCvar("ui_BrandGametypeEnabled", level.ui_BrandGametypeEnabled);
-		}
+               if(level.ui_BrandGametypeEnabled != getCvar("ui_BrandGametypeEnabled")) {
+                       level.ui_BrandGametypeEnabled = getCvar("ui_BrandGametypeEnabled");
+                       setCvar("ui_BrandGametypeEnabled", level.ui_BrandGametypeEnabled);
+               }
+
+               awe_server_logo_text = getCvar("awe_server_logo_text");
+               if(level.awe_server_logo_text != awe_server_logo_text) {
+                       level.awe_server_logo_text = awe_server_logo_text;
+                       setCvar("awe_server_logo_text", level.awe_server_logo_text);
+               }
 
 		if(level.ui_AutoAdmin_AFK_NotifyPlayer != getCvar("ui_AutoAdmin_AFK_NotifyPlayer")) {
 			level.ui_AutoAdmin_AFK_NotifyPlayer = getCvar("ui_AutoAdmin_AFK_NotifyPlayer");

--- a/the_empire_mod.txt
+++ b/the_empire_mod.txt
@@ -17,6 +17,7 @@ ui_BrandColorSecondary "1"
 ui_BrandColorTertiary "2"
 ui_BrandNextMap "^1~^3empire ^2| ^1Next:"
 ui_BrandGametypeEnabled "1"
+awe_server_logo_text ""
 
 // AutoAdmin
 ui_AutoAdmin_AFK_NotifyPlayer "^1~^3empire ^2| ^1automod: ^3You have been detected as ^1AFK^3. You will be forced into spectator mode in "


### PR DESCRIPTION
## Summary
- add `awe_server_logo_text` CVAR in AWE HUD setup
- initialize `level.awe_serverlogotext` using the new CVAR if provided
- expose the CVAR via `makeCvarServerInfo`
- document the new setting

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_684dbd31eff08329856da858005cb0b8