### PR TITLE
Add configurable rank thresholds

### DIFF
--- a/maps/MP/gametypes/_rank_gmi.gsc
+++ b/maps/MP/gametypes/_rank_gmi.gsc
@@ -48,45 +48,45 @@ InitializeBattleRank()
 
 	// set up the rank points
 	if(!isdefined(game["br_rank_1"]))	// points to achieve first rank
-		game["br_rank_1"] = game["br_ppr"] * 3;
+		game["br_rank_1"] = getConfigInt("awe_br1", game["br_ppr"] * 3);
 	if(!isdefined(game["br_rank_2"]))	// points to achieve second rank
-		game["br_rank_2"] = game["br_ppr"] * 6;
+		game["br_rank_2"] = getConfigInt("awe_br2", game["br_ppr"] * 6);
 	if(!isdefined(game["br_rank_3"]))	// points to achieve third rank
-		game["br_rank_3"] = game["br_ppr"] * 9;
+		game["br_rank_3"] = getConfigInt("awe_br3", game["br_ppr"] * 9);
 	if(!isdefined(game["br_rank_4"]))	// points to achieve fourth rank
-		game["br_rank_4"] = game["br_ppr"] * 12;
+		game["br_rank_4"] = getConfigInt("awe_br4", game["br_ppr"] * 12);
 		
 	// set up the ammo values for the various ranks
 	// remember that they will already have one clip in the gun
-	game["br_ammo_gunclips_0"] = 4;
-	game["br_ammo_gunclips_1"] = 4;
-	game["br_ammo_gunclips_2"] = 5;
-	game["br_ammo_gunclips_3"] = 5;
-	game["br_ammo_gunclips_4"] = 6;
+	game["br_ammo_gunclips_0"] = getConfigInt("awe_br0_gunclips", 4);
+	game["br_ammo_gunclips_1"] = getConfigInt("awe_br1_gunclips", 4);
+	game["br_ammo_gunclips_2"] = getConfigInt("awe_br2_gunclips", 5);
+	game["br_ammo_gunclips_3"] = getConfigInt("awe_br3_gunclips", 5);
+	game["br_ammo_gunclips_4"] = getConfigInt("awe_br4_gunclips", 6);
 
-	game["br_ammo_pistolclips_0"] = 2;
-	game["br_ammo_pistolclips_1"] = 3;
-	game["br_ammo_pistolclips_2"] = 3;
-	game["br_ammo_pistolclips_3"] = 4;
-	game["br_ammo_pistolclips_4"] = 4;
+	game["br_ammo_pistolclips_0"] = getConfigInt("awe_br0_pistolclips", 2);
+	game["br_ammo_pistolclips_1"] = getConfigInt("awe_br1_pistolclips", 3);
+	game["br_ammo_pistolclips_2"] = getConfigInt("awe_br2_pistolclips", 3);
+	game["br_ammo_pistolclips_3"] = getConfigInt("awe_br3_pistolclips", 4);
+	game["br_ammo_pistolclips_4"] = getConfigInt("awe_br4_pistolclips", 4);
 
-	game["br_ammo_grenades_0"] = 1;
-	game["br_ammo_grenades_1"] = 1;
-	game["br_ammo_grenades_2"] = 1;
-	game["br_ammo_grenades_3"] = 2;
-	game["br_ammo_grenades_4"] = 2;
+	game["br_ammo_grenades_0"] = getConfigInt("awe_br0_grenades", 1);
+	game["br_ammo_grenades_1"] = getConfigInt("awe_br1_grenades", 1);
+	game["br_ammo_grenades_2"] = getConfigInt("awe_br2_grenades", 1);
+	game["br_ammo_grenades_3"] = getConfigInt("awe_br3_grenades", 2);
+	game["br_ammo_grenades_4"] = getConfigInt("awe_br4_grenades", 2);
 
-	game["br_ammo_smoke_grenades_0"] = 1;
-	game["br_ammo_smoke_grenades_1"] = 1;
-	game["br_ammo_smoke_grenades_2"] = 1;
-	game["br_ammo_smoke_grenades_3"] = 2;
-	game["br_ammo_smoke_grenades_4"] = 2;
+	game["br_ammo_smoke_grenades_0"] = getConfigInt("awe_br0_smokegrenades", 1);
+	game["br_ammo_smoke_grenades_1"] = getConfigInt("awe_br1_smokegrenades", 1);
+	game["br_ammo_smoke_grenades_2"] = getConfigInt("awe_br2_smokegrenades", 1);
+	game["br_ammo_smoke_grenades_3"] = getConfigInt("awe_br3_smokegrenades", 2);
+	game["br_ammo_smoke_grenades_4"] = getConfigInt("awe_br4_smokegrenades", 2);
 	
-	game["br_ammo_satchel_charge_0"] = 0;
-	game["br_ammo_satchel_charge_1"] = 0;
-	game["br_ammo_satchel_charge_2"] = 0;
-	game["br_ammo_satchel_charge_3"] = 0;
-	game["br_ammo_satchel_charge_4"] = 1;
+	game["br_ammo_satchel_charge_0"] = getConfigInt("awe_br0_satchels", 0);
+	game["br_ammo_satchel_charge_1"] = getConfigInt("awe_br1_satchels", 0);
+	game["br_ammo_satchel_charge_2"] = getConfigInt("awe_br2_satchels", 0);
+	game["br_ammo_satchel_charge_3"] = getConfigInt("awe_br3_satchels", 0);
+	game["br_ammo_satchel_charge_4"] = getConfigInt("awe_br4_satchels", 1);
 	
 	if( GetCvar("scr_artillery_first_interval") == "" )
 		setCvar("scr_artillery_first_interval", "45"); 
@@ -98,8 +98,21 @@ InitializeBattleRank()
 	//
 	// DEBUG
 	//
-	if(getCvar("scr_forcerank") == "")
-		setCvar("scr_forcerank", "0"); 
+       if(getCvar("scr_forcerank") == "")
+               setCvar("scr_forcerank", "0");
+}
+
+// -----------------------------------------------------------------------------
+//      getConfigInt
+//
+//              Returns the integer value of a cvar or a fallback if unset
+// -----------------------------------------------------------------------------
+getConfigInt(name, fallback)
+{
+       if ( getCvar(name) == "" )
+               return fallback;
+
+       return getCvarInt(name);
 }
 
 // ----------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add `getConfigInt` helper for retrieving cvars with fallbacks
- use the new helper to configure rank thresholds
- make battle-rank ammo counts configurable via cvars

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684de05097ec832980bac26477e30a7d