### PR TITLE
Add awe_server_logo_text cvar

### DIFF
--- a/maps/MP/gametypes/_awe.gsc
+++ b/maps/MP/gametypes/_awe.gsc
@@ -2391,8 +2391,9 @@ updateGametypeCvars(init)
 
 		// Hud
 		level.awe_showlogo = cvardef("awe_show_logo", 1, 0, 1, "int");	
-		level.awe_showserverlogo = cvardef("awe_show_server_logo", 0, 0, 2, "int");	
-		level.awe_showsdtimer_cvar = cvardef("awe_show_sd_timer", 0, 0, 1, "int");	
+               level.awe_showserverlogo = cvardef("awe_show_server_logo", 0, 0, 2, "int");
+               level.awe_serverlogotext = cvardef("awe_server_logo_text", "", "", "", "string");
+               level.awe_showsdtimer_cvar = cvardef("awe_show_sd_timer", 0, 0, 1, "int");
 		if(level.awe_showsdtimer_cvar)
 			level.awe_showsdtimer = true;
 		else

--- a/server_logo/_awe_server_logo.gsc
+++ b/server_logo/_awe_server_logo.gsc
@@ -1,22 +1,25 @@
-logo() { level.awe_serverlogotext = 
-
-	// Replace the text between the quotationmarks with your server and/or clan name
-	// Colorcoding can be used
-	// ^1 = red
-	// ^2 = green
-	// ^3 = yellow
-	// ^4 = blue
-	// ^5 = cyan
-	// ^6 = magenta
-	// ^7 = white
-	// ^8 = dark purple
-	// ^9 = gray
-	// ^0 = black
+logo()
+{
+       level.awe_serverlogotext = getcvar("awe_server_logo_text");
+       if(level.awe_serverlogotext == "")
+       {
+               // Replace the text between the quotationmarks with your server and/or clan name
+               // Colorcoding can be used
+               // ^1 = red
+               // ^2 = green
+               // ^3 = yellow
+               // ^4 = blue
+               // ^5 = cyan
+               // ^6 = magenta
+               // ^7 = white
+               // ^8 = dark purple
+               // ^9 = gray
+               // ^0 = black
 
 ///// DON'T CHANGE ANYTHING ABOVE THIS LINE /////
 
-	&"^7Custom logo file ^1NOT ^7installed correctly"
+               level.awe_serverlogotext = &"^7Custom logo file ^1NOT ^7installed correctly";
 
 ///// DON'T CHANGE ANYTHING BELOW THIS LINE /////
-;
+       }
 }

--- a/the_empire_mod.txt
+++ b/the_empire_mod.txt
@@ -17,6 +17,7 @@ ui_BrandColorSecondary "1"
 ui_BrandColorTertiary "2"
 ui_BrandNextMap "^1~^3empire ^2| ^1Next:"
 ui_BrandGametypeEnabled "1"
+awe_server_logo_text "" // text displayed under the compass
 
 // AutoAdmin
 ui_AutoAdmin_AFK_NotifyPlayer "^1~^3empire ^2| ^1automod: ^3You have been detected as ^1AFK^3. You will be forced into spectator mode in "


### PR DESCRIPTION
## Summary
- allow setting custom server logo text via new `awe_server_logo_text` cvar
- display the cvar value or fallback to default logo
- document the cvar

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684de83a66708329b59a83f2f3ba9a57