### PR TITLE
Clean up duplicate CVARs in empire.cfg

### DIFF
--- a/empire.cfg
+++ b/empire.cfg
@@ -56,7 +56,6 @@ seta sv_gamespy "1"
 
 // General Settings
 set g_deadchat "1"
-set scr_rank_ppr "5"
 
 
 //AWE
@@ -1184,7 +1183,7 @@ set scr_drophealth "1" //Do players drop health packs when they die?
 // Battleranks 
 set scr_battlerank "0" // Turns Battle Rank on/off
 set scr_forcerank "0" // Forces all players to this rank at all times 
-set scr_rank_ppr "10" //Sets the Points Per Rank
+set scr_rank_ppr "5" //Sets the Points Per Rank
 
 
 // ************************************************
@@ -1353,17 +1352,8 @@ set g_allowvotetypemap "1"
 set g_allowvotemap "1"
 set g_allowvotemaprotate "1"
 set g_allowvotemaprestart "1"
-set scr_shellshock "0"
-set scr_drophealth "1"
-set scr_battlerank "1"
-
 // KillCam
 set scr_killcam "0"
-set scr_freelook "0"
-set scr_spectateenemy "0"
-
-// Auto Team Balance
-set scr_teambalance "1"
 
 // Friendly Fire
 set scr_friendlyfire "0" //0 - off 1 - on 2 - reflect damage 3 - Shared
@@ -1440,12 +1430,6 @@ set scr_re_scorelimit ""
 set scr_re_showcarrier "0" 
 set scr_re_timelimit "20" 
 
-//Search and Destroy Default Description 
-set scr_sd_graceperiod "15" 
-set scr_sd_roundlength "3" 
-set scr_sd_roundlimit "10" 
-set scr_sd_scorelimit "6" 
-set scr_sd_timelimit "30" 
 
 //Team Deathmatch Default Description 
 set scr_tdm_scorelimit "100" 


### PR DESCRIPTION
## Summary
- remove duplicate CVAR definitions in empire.cfg
- keep earliest values for gameplay settings
- organize gameplay section to group CVARs together

## Testing
- `grep -nE "^set" empire.cfg | awk '{print $2}' | sort | uniq -d`


------
https://chatgpt.com/codex/tasks/task_e_684ef7b9cea88329b2defc5bbb11c848