### PR TITLE
Add AFK message helper and placeholder support

### DIFF
--- a/empire.cfg
+++ b/empire.cfg
@@ -11,8 +11,8 @@ set ui_BrandGametypeEnabled "1"
 set awe_server_logo_text "^1~ ^3empire ^2| ^1TEST"
 
 // AutoAdmin
-set ui_AutoAdmin_AFK_NotifyPlayer "^1~^3empire ^2| ^1automod: ^3You have been detected as ^1AFK^3. You will be forced into spectator mode in "
-set ui_AutoAdmin_AFK_NotifyPublic " ^3has been detected as AFK and will be forced into spectator mode in "
+set ui_AutoAdmin_AFK_NotifyPlayer "^1~^3empire ^2| ^1automod: ^3You have been detected as ^1AFK^3. You will be forced into spectator mode in {{TIME}} seconds."
+set ui_AutoAdmin_AFK_NotifyPublic "{{PLAYER}} has been detected as AFK and will be forced into spectator mode in {{TIME}} seconds."
 set ui_AutoAdmin_AFK_NotifyActionTaken "^1~^3empire ^2| ^1automod: ^3You have been forced into spectator mode due to ^1AFK^3 behavior."
 set ui_AutoAdmin_AFK_NotifyRemoved "^1~^3empire ^2| ^1automod: ^3You are no longer marked as ^1AFK^3."
 

--- a/maps/MP/gametypes/_awe.gsc
+++ b/maps/MP/gametypes/_awe.gsc
@@ -1876,7 +1876,22 @@ strReplace(s, target, replacement)
 			i++;
 		}
 	}
-	return newstr;
+        return newstr;
+}
+
+// Format a message by replacing placeholders with provided values
+formatMessage(msg, player, time)
+{
+        if (isdefined(time))
+        {
+                tstr = "^" + getcvar("ui_BrandColorSecondary") + time + " ^" + getcvar("ui_BrandColorPrimary");
+                msg = strReplace(msg, "{{TIME}}", tstr);
+        }
+
+        if (isdefined(player))
+                msg = strReplace(msg, "{{PLAYER}}", player.name);
+
+        return msg;
 }
 
 // Strip blanks at start and end of string
@@ -4651,7 +4666,7 @@ NotAFK()
     {
         self.awe_camptimer destroy();
         self.awe_camptimer = undefined;
-		self iprintln(getcvar("ui_AutoAdmin_AFK_NotifyRemoved"));
+                self iprintln(formatMessage(getcvar("ui_AutoAdmin_AFK_NotifyRemoved"), self));
     }
     // Reset your AFK indicator (or counter) so camper() can be triggered again.
     self.awe_objnum = undefined;
@@ -4958,13 +4973,13 @@ camper()
             {
                 if (level.awe_allplayers[i] == self)
                 {
-		    //^1~^3empire ^2| ^1dev
-					level.awe_allplayers[i] iprintlnbold(getcvar("ui_AutoAdmin_AFK_NotifyPlayer") + " ^" + getcvar("ui_BrandColorSecondary") + markTime + " ^" + getcvar("ui_BrandColorPrimary") + "seconds.");
+                    //^1~^3empire ^2| ^1dev
+                                        level.awe_allplayers[i] iprintlnbold(formatMessage(getcvar("ui_AutoAdmin_AFK_NotifyPlayer"), self, markTime));
                 }
                 else
                 {
                     //level.awe_allplayers[i] iprintln(self.name + " has been detected as AFK and will be forced into spectator mode in " + markTime + " seconds.");
-					level.awe_allplayers[i] iprintln(self.name + getcvar("ui_AutoAdmin_AFK_NotifyPublic") + " ^" + getcvar("ui_BrandColorSecondary") + markTime + " ^" + getcvar("ui_BrandColorPrimary") + "seconds.");
+                                        level.awe_allplayers[i] iprintln(formatMessage(getcvar("ui_AutoAdmin_AFK_NotifyPublic"), self, markTime));
                 }
             }
         }
@@ -5002,7 +5017,7 @@ camper()
     self thread maps\mp\gametypes\_awe::spawnSpectator();
     
     if (isAlive(self))	//"^1~^3empire ^2| ^1automod: ^3You have been detected as ^1AFK^3. You will be forced into spectator mode in ^1" + markTime + "^3 seconds."
-		self iprintlnbold(getcvar("ui_AutoAdmin_AFK_NotifyActionTaken"));
+                self iprintlnbold(formatMessage(getcvar("ui_AutoAdmin_AFK_NotifyActionTaken"), self));
     
     self.awe_camper = undefined;
 }

--- a/the_empire_mod.txt
+++ b/the_empire_mod.txt
@@ -20,8 +20,8 @@ ui_BrandGametypeEnabled "1"
 awe_server_logo_text "" // text displayed under the compass
 
 // AutoAdmin
-ui_AutoAdmin_AFK_NotifyPlayer "^1~^3empire ^2| ^1automod: ^3You have been detected as ^1AFK^3. You will be forced into spectator mode in "
-ui_AutoAdmin_AFK_NotifyPublic " has been detected as AFK and will be forced into spectator mode in "
+ui_AutoAdmin_AFK_NotifyPlayer "^1~^3empire ^2| ^1automod: ^3You have been detected as ^1AFK^3. You will be forced into spectator mode in {{TIME}} seconds."
+ui_AutoAdmin_AFK_NotifyPublic "{{PLAYER}} has been detected as AFK and will be forced into spectator mode in {{TIME}} seconds."
 ui_AutoAdmin_AFK_NotifyActionTaken "^1~^3empire ^2| ^1automod: ^3You have been forced into spectator mode due to ^1AFK^3 behavior."
 ui_AutoAdmin_AFK_NotifyRemoved "^1~^3empire ^2| ^1automod: ^3You are no longer marked as ^1AFK^3."
 


### PR DESCRIPTION
## Summary
- insert `formatMessage` helper to format AFK notifications
- switch AFK related prints to use `formatMessage`
- update AFK notification cvars to use `{{TIME}}` and `{{PLAYER}}` placeholders

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684f0d096f7c8329ab0d02e6d56fd80c