### PR TITLE
Fix AFK mark time cvar usage

### DIFF
--- a/maps/MP/gametypes/_awe.gsc
+++ b/maps/MP/gametypes/_awe.gsc
@@ -4960,7 +4960,11 @@ camper()
     self.awe_camper = true;
     
     // Retrieve the marking period from the anticamp marktime cvar.
-    markTime = level.awe_anticamp_marktime;
+    // NOTE: the cvar value is stored in level.awe_anticampmarktime when
+    //       _awe::Setup() initializes all mod cvars. Use that variable here
+    //       so that user configured values (e.g. awe_anticamp_marktime) are
+    //       respected.
+    markTime = level.awe_anticampmarktime;
     if (!isdefined(markTime) || markTime <= 0)
         markTime = 30; // default to 30 seconds if not set
     


### PR DESCRIPTION
## Summary
- hook up awe_anticamp_marktime cvar correctly by using `level.awe_anticampmarktime`

## Testing
- `grep -n awe_anticampmarktime -n maps/MP/gametypes/_awe.gsc`


------
https://chatgpt.com/codex/tasks/task_e_684f2121d50c8329894de72c7162ea2f