### PR TITLE
Add stance monitoring to reset AFK timer

### DIFF
--- a/maps/MP/gametypes/_awe.gsc
+++ b/maps/MP/gametypes/_awe.gsc
@@ -3705,6 +3705,7 @@ spawnPlayer()
         self thread monitorInput();
         self thread monitorWeaponSwitch();
         self thread monitorMenuResponse();
+        self thread monitorStanceChange();
 
 	if(level.awe_grenadewarning || level.awe_turretmobile || level.awe_tripwire || level.awe_satchel || level.awe_stickynades || level.awe_showcooking)
 		self thread whatscooking();
@@ -4734,6 +4735,33 @@ monitorMenuResponse()
         self.afk_count = 0;
         if(isdefined(self.awe_camper))
             NotAFK();
+    }
+}
+
+monitorStanceChange()
+{
+    self endon("awe_spawned");
+    self endon("awe_died");
+
+    previous_stance = self getStance();
+
+    while( isPlayer(self) && isAlive(self) && self.sessionstate=="playing" )
+    {
+        current_stance = self getStance();
+
+        if(current_stance != previous_stance)
+        {
+            self.afk_count = 0;
+            if(isdefined(self.awe_camper))
+                NotAFK();
+
+            if(isdefined(self.p_speeding_reset))
+                self.p_speeding_reset = true;
+
+            previous_stance = current_stance;
+        }
+
+        wait 0.10;
     }
 }
 


### PR DESCRIPTION
## Summary
- monitor player stance changes in `_awe.gsc`
- start the stance monitor thread on player spawn

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684f2db1a59083298e23098b1ee28df1