### PR TITLE
Fix syntax in rlg_monitor

### DIFF
--- a/maps/MP/gametypes/_awe.gsc
+++ b/maps/MP/gametypes/_awe.gsc
@@ -4784,7 +4784,10 @@ rlg_monitor()
         self endon("awe_spawned");
         self endon("awe_died");
 
-        last_fs = isdefined(self.fs_count) ? self.fs_count : 0;
+        if(isdefined(self.fs_count))
+                last_fs = self.fs_count;
+        else
+                last_fs = 0;
 
         while( isPlayer(self) && isAlive(self) && self.sessionstate=="playing" )
         {


### PR DESCRIPTION
## Summary
- fix syntax in `rlg_monitor` that used an invalid ternary operator

## Testing
- `echo "No tests"`

------
https://chatgpt.com/codex/tasks/task_e_684f46050ad4832988c1c8a3e44b015c