### PR TITLE
Fix UO map vote offset

### DIFF
--- a/maps/MP/gametypes/_pam_sd.gsc
+++ b/maps/MP/gametypes/_pam_sd.gsc
@@ -469,7 +469,8 @@ PamMain()
         level.mapvotetext["MapVote"]      = &"Press ^2FIRE^7 to vote   Votes";
         level.mapvotetext["TimeLeft"]     = &"Time Left: ";
         level.mapvotetext["MapVoteHeader"] = &"Next Map Vote";
-        level.awe_mapvotehudoffset = 30;       // not UO
+        if(!isdefined(level.awe_uo))
+                level.awe_mapvotehudoffset = 30;       // not UO
 	
 }
 


### PR DESCRIPTION
## Summary
- fix PAM SD map vote HUD offset when UO is not detected

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684f4c00d3a88329bddf587917948bb6