### PR TITLE
Fix map vote offset in PAM SD mode

### DIFF
--- a/_rPAM_rules/_pam_messagecenter.gsc
+++ b/_rPAM_rules/_pam_messagecenter.gsc
@@ -23,6 +23,7 @@ messages()
 // 
 
 {
+	level endon("intermission");
 
 	// Make sure the server runs even if message center is not set up.
 if(getcvar("sv_message1") == "")


### PR DESCRIPTION
## Summary
- stop the message center loop when the map enters intermission

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684f542ba5a08329a3b97a48f8f9b1cd