### PR TITLE
Fix map vote HUD alignment for PAMUO SD

### DIFF
--- a/maps/MP/gametypes/_awe_mapvote.gsc
+++ b/maps/MP/gametypes/_awe_mapvote.gsc
@@ -7,10 +7,10 @@ Initialise()
 {
 	if(!level.awe_mapvote) return;
 
-	if(isdefined(level.awe_uo))
-		level.awe_mapvotehudoffset = 0;
-	else
-		level.awe_mapvotehudoffset = 30;
+       // Use a consistent offset so vote counters line up correctly with the
+       // printed map names across all game variants.  An offset of 0 caused the
+       // counters to appear two rows below their maps in PAMUO Search & Destroy.
+       level.awe_mapvotehudoffset = 30;
 
 	// Small wait
 	wait .5;

--- a/maps/MP/gametypes/_pam_sd.gsc
+++ b/maps/MP/gametypes/_pam_sd.gsc
@@ -466,7 +466,8 @@ PamMain()
         level.awe_mapvotereplay = getCvarInt("awe_map_vote_replay");
         level.awe_spawnspectatorname = "mp_searchanddestroy_intermission";
         level.mapvotetext = [];
-        level.mapvotetext["MapVote"]      = &"Press ^2FIRE^7 to vote   Votes";
+       // Extra spaces keep the "Votes" column aligned with the HUD vote counts
+       level.mapvotetext["MapVote"]      = &"Press ^2FIRE^7 to vote                           Votes";
         level.mapvotetext["TimeLeft"]     = &"Time Left: ";
         level.mapvotetext["MapVoteHeader"] = &"Next Map Vote";
         if(!isdefined(level.awe_uo))


### PR DESCRIPTION
## Summary
- ensure map vote HUD offset matches other gametypes
- keep votes column aligned with header text

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684f595e29ac832994d5b7980597d5eb