### PR TITLE
Fix map vote header visibility in PAM SD

### DIFF
--- a/maps/MP/gametypes/_pam_sd.gsc
+++ b/maps/MP/gametypes/_pam_sd.gsc
@@ -468,8 +468,12 @@ PamMain()
         level.mapvotetext = [];
        // Extra spaces keep the "Votes" column aligned with the HUD vote counts
        level.mapvotetext["MapVote"]      = &"Press ^2FIRE^7 to vote                           Votes";
-        level.mapvotetext["TimeLeft"]     = &"Time Left: ";
-        level.mapvotetext["MapVoteHeader"] = &"Next Map Vote";
+       level.mapvotetext["TimeLeft"]     = &"Time Left: ";
+       level.mapvotetext["MapVoteHeader"] = &"Next Map Vote";
+       // Ensure map vote strings display correctly
+       precacheString(level.mapvotetext["MapVote"]);
+       precacheString(level.mapvotetext["TimeLeft"]);
+       precacheString(level.mapvotetext["MapVoteHeader"]);
         if(!isdefined(level.awe_uo))
                 level.awe_mapvotehudoffset = 30;       // not UO
 	


### PR DESCRIPTION
## Summary
- preload map vote header text in PAM SD so it renders correctly

## Testing
- `grep -n "precacheString(level.mapvotetext" -n maps/MP/gametypes/_pam_sd.gsc`

------
https://chatgpt.com/codex/tasks/task_e_684f697005d4832997b8a52538bfd90c