### PR TITLE
Adjust camper check for LMG users

### DIFF
--- a/maps/MP/gametypes/_awe.gsc
+++ b/maps/MP/gametypes/_awe.gsc
@@ -5091,11 +5091,11 @@ monitorme()
                         }
                         else
                         {
-                                // Check for campers
-                                if(self.awe_pace == 0)
-                                        self.afk_count++;
-                                else
-                                        self.afk_count = 0;
+                               // Check for campers - ignore players using LMGs
+                               if(self.awe_pace == 0 && !isWeaponType("lmg", self GetCurrentWeapon()))
+                                       self.afk_count++;
+                               else
+                                       self.afk_count = 0;
 
                                 if(self.afk_count >= level.awe_anticamptime)
                                 {


### PR DESCRIPTION
## Summary
- avoid AFK counting when player uses an LMG

## Testing
- `grep -n "isWeaponType("lmg"" maps/MP/gametypes/_awe.gsc`

------
https://chatgpt.com/codex/tasks/task_e_68648d5097088329a24040419509caca