### PR TITLE
Add forced map vote cvar

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ For additional notes on mod changes see `the_empire_mod.txt`.
 
 ## Changelog
 
+- **v1.04** - Added `awe_map_vote_force` to always include specified maps in voting.
 - **v1.03** - Added map rotation history to improve map voting.
 - **v1.02** - Added reload glitch detection with new cvars for AWE.
 - **v1.01** - Fixed display bug when notifying players about AFK status.

--- a/empire.cfg
+++ b/empire.cfg
@@ -179,6 +179,7 @@ set awe_map_vote_replay "0" // Set last choice as an option to replay the same m
 
 set awe_map_history_size "5" // Number of recent maps to exclude from votes
 set awe_map_history "" // Rotation history, managed automatically
+set awe_map_vote_force "" // Space separated rotation string of maps to always include in votes
 //////////////////////
 // Server/Clan logo //
 //////////////////////

--- a/maps/MP/gametypes/_awe.gsc
+++ b/maps/MP/gametypes/_awe.gsc
@@ -2063,9 +2063,10 @@ updateGametypeCvars(init)
 	level.awe_coldbreath = cvardef("awe_cold_breath", 0, 0, 1, "int");
 
 	// Map voting	
-	level.awe_mapvote = cvardef("awe_map_vote", 0, 0, 1, "int");
-	level.awe_mapvotetime = cvardef("awe_map_vote_time", 30, 10, 180, "int");
-	level.awe_mapvotereplay = cvardef("awe_map_vote_replay",0,0,1,"int");
+        level.awe_mapvote = cvardef("awe_map_vote", 0, 0, 1, "int");
+        level.awe_mapvotetime = cvardef("awe_map_vote_time", 30, 10, 180, "int");
+        level.awe_mapvotereplay = cvardef("awe_map_vote_replay",0,0,1,"int");
+        level.awe_mapvoteforce = cvardef("awe_map_vote_force", "", "", "", "string");
         // Map rotation history
         level.awe_maphistory = cvardef("awe_map_history", "", "", "", "string");
         level.awe_maphistorysize = cvardef("awe_map_history_size", 5, 1, 20, "int");

--- a/maps/MP/gametypes/_awe_mapvote.gsc
+++ b/maps/MP/gametypes/_awe_mapvote.gsc
@@ -708,10 +708,38 @@ getRandomMapRotation()
                }
        }
 
-        // Shuffle the array for better randomization
-        shuffleArray(x.maps);
+       // Shuffle the array for better randomization
+       shuffleArray(x.maps);
 
-	return x;
+       // Always include maps specified via cvar
+       force = strip(getcvar("awe_map_vote_force"));
+       if(force != "")
+       {
+               forced = parseRotationString(force);
+               if(isdefined(forced))
+               {
+                       for(f=0; f<forced.size; f++)
+                       {
+                               for(k=0; k<x.maps.size; k++)
+                               {
+                                       if(x.maps[k]["map"] == forced[f]["map"] && x.maps[k]["gametype"] == forced[f]["gametype"])
+                                       {
+                                               x.maps = removeRotationIndex(x.maps, k);
+                                               break;
+                                       }
+                               }
+                       }
+
+                       newarr = [];
+                       for(f=0; f<forced.size; f++)
+                               newarr[newarr.size] = forced[f];
+                       for(k=0; k<x.maps.size; k++)
+                               newarr[newarr.size] = x.maps[k];
+                       x.maps = newarr;
+               }
+       }
+
+       return x;
 }
 
 getActivePlayerCount()

--- a/the_empire_mod.txt
+++ b/the_empire_mod.txt
@@ -17,6 +17,10 @@ Added map rotation history tracking. New cvars:
 awe_map_history_size "5"
 awe_map_history ""
 
+v1.04
+Always include specified maps in gametype voting. New cvar:
+awe_map_vote_force ""
+
 v1.0
 
 Added the following global cvars:


### PR DESCRIPTION
## Summary
- add `awe_map_vote_force` cvar to allow always including maps
- insert forced maps into the vote rotation
- document new feature in config and changelogs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6877fbdf37f0832997d92b7e02f6fc6a