### PR TITLE
Add gametype rotation cvars

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ For additional notes on mod changes see `the_empire_mod.txt`.
 
 ## Changelog
 
+- **v1.05** - Added gametype rotation cvars for configuring allowed gametypes and history.
 - **v1.04** - Added `awe_map_vote_force` to always include specified maps in voting.
 - **v1.03** - Added map rotation history to improve map voting.
 - **v1.02** - Added reload glitch detection with new cvars for AWE.

--- a/empire.cfg
+++ b/empire.cfg
@@ -180,6 +180,13 @@ set awe_map_vote_replay "0" // Set last choice as an option to replay the same m
 set awe_map_history_size "5" // Number of recent maps to exclude from votes
 set awe_map_history "" // Rotation history, managed automatically
 set awe_map_vote_force "" // Space separated rotation string of maps to always include in votes
+/////////////////////////
+// Gametype rotation   //
+/////////////////////////
+set awe_gametype_mode "1" // Gametype selection mode (1=static, 2=dynamic, 3=alternating) (default 1)
+set awe_allowed_gametypes "" // Space separated list of gametypes allowed for selection
+set awe_gametype_history_size "5" // Number of recent gametypes to exclude from selection
+set awe_gametype_history "" // Gametype history, managed automatically
 //////////////////////
 // Server/Clan logo //
 //////////////////////

--- a/maps/MP/gametypes/_awe.gsc
+++ b/maps/MP/gametypes/_awe.gsc
@@ -95,9 +95,10 @@ Callback_StartGameType()
 	level.awe_disable = cvardef("awe_disable",0,0,1,"int");
 	if(level.awe_disable) return;
 
-	// Set up variables
+        // Set up variables
         maps\mp\gametypes\_awe_mapvote::UpdateMapHistory();
-	setupVariables();
+        maps\mp\gametypes\_awe_mapvote::UpdateGametypeHistory();
+        setupVariables();
 
 	// Find map limits
 	findmapdimensions();
@@ -2062,16 +2063,21 @@ updateGametypeCvars(init)
 	// Cold breath
 	level.awe_coldbreath = cvardef("awe_cold_breath", 0, 0, 1, "int");
 
-	// Map voting	
-	level.awe_mapvote = cvardef("awe_map_vote", 0, 0, 1, "int");
-	level.awe_mapvotetime = cvardef("awe_map_vote_time", 30, 10, 180, "int");
-	level.awe_mapvotereplay = cvardef("awe_map_vote_replay",0,0,1,"int");
+        // Map voting
+        level.awe_mapvote = cvardef("awe_map_vote", 0, 0, 1, "int");
+        level.awe_mapvotetime = cvardef("awe_map_vote_time", 30, 10, 180, "int");
+        level.awe_mapvotereplay = cvardef("awe_map_vote_replay",0,0,1,"int");
         // Map rotation history
         level.awe_maphistory = cvardef("awe_map_history", "", "", "", "string");
         level.awe_maphistorysize = cvardef("awe_map_history_size", 5, 1, 20, "int");
+        // Gametype rotation
+        level.awe_gametypemode = cvardef("awe_gametype_mode", 1, 1, 3, "int");
+        level.awe_allowedgametypes = cvardef("awe_allowed_gametypes", "", "", "", "string");
+        level.awe_gametypehistory = cvardef("awe_gametype_history", "", "", "", "string");
+        level.awe_gametypehistorysize = cvardef("awe_gametype_history_size", 5, 1, 20, "int");
 
-	// Show grenade cooking
-	level.awe_showcooking = cvardef("awe_show_cooking", 1, 0, 1, "int");
+        // Show grenade cooking
+        level.awe_showcooking = cvardef("awe_show_cooking", 1, 0, 1, "int");
 	
 	// First aid
 	level.awe_firstaid	= cvardef("awe_firstaid",0,0,1,"int");

--- a/maps/MP/gametypes/_awe_mapvote.gsc
+++ b/maps/MP/gametypes/_awe_mapvote.gsc
@@ -967,6 +967,50 @@ UpdateMapHistory()
         setcvar("awe_map_history", buildRotationString(history));
 }
 
+UpdateGametypeHistory()
+{
+        size = getcvarint("awe_gametype_history_size");
+        if(!isdefined(size) || size <= 0)
+                return;
+
+        history = getGametypeHistory();
+
+        cur = getcvar("g_gametype");
+
+        for(i=0;i<history.size;i++)
+        {
+                if(history[i] == cur)
+                {
+                        history = removeRotationIndex(history, i);
+                        break;
+                }
+        }
+
+        while(history.size >= size)
+                history = removeRotationIndex(history, 0);
+
+        history[history.size] = cur;
+
+        setcvar("awe_gametype_history", buildGametypeString(history));
+}
+
+getGametypeHistory()
+{
+        histstr = strip(getcvar("awe_gametype_history"));
+        if(histstr == "")
+                return [];
+
+        return explode(histstr, " ");
+}
+
+buildGametypeString(arr)
+{
+        str = "";
+        for(i=0; i<arr.size; i++)
+                str += " " + arr[i];
+        return strip(str);
+}
+
 parseRotationString(rot)
 {
        j = 0;


### PR DESCRIPTION
## Summary
- add gametype rotation cvars for mode, allowed types, and history
- track gametype history during startup
- document new settings in server config

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e5334a73083299f6f255091f18fb7