### PR TITLE
feat: add gametype rotation support

### DIFF
--- a/maps/MP/gametypes/_awe.gsc
+++ b/maps/MP/gametypes/_awe.gsc
@@ -97,7 +97,7 @@ Callback_StartGameType()
 
         // Set up variables
         maps\mp\gametypes\_awe_mapvote::UpdateMapHistory();
-        maps\mp\gametypes\_awe_mapvote::UpdateGametypeHistory();
+        maps\mp\gametypes\_awe_mapvote::UpdateGametypeHistory(getcvar("g_gametype"));
         setupVariables();
 
 	// Find map limits


### PR DESCRIPTION
## Summary
- add helpers to parse allowed gametypes, choose next gametype, and track gametype history
- respect gametype selection mode and history when building map vote candidates
- update gametype history when a map vote winner is chosen
- preserve current gametype when parsing rotation strings and seed history with it

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e5b8872708329bb113a371fd06e86