### PR TITLE
Fix mapvote cvardef call to use _awe namespace

### DIFF
--- a/maps/MP/gametypes/_awe_mapvote.gsc
+++ b/maps/MP/gametypes/_awe_mapvote.gsc
@@ -335,7 +335,7 @@ ParseMapVoteGametypeWeights()
 	parsed["sum"] = 0;
 	parsed["count"] = 0;
 
-	weightsraw = cvardef("awe_random_gametype_weights", "", "", "", "string");
+	weightsraw = maps\mp\gametypes\_awe::cvardef("awe_random_gametype_weights", "", "", "", "string");
 	weightsraw = strip(weightsraw);
 	if(weightsraw == "")
 		return parsed;


### PR DESCRIPTION
### Motivation
- A runtime compile error occurred because `_awe_mapvote.gsc` called `cvardef(...)` unqualified where that helper is not defined locally, causing the engine to treat `cvardef` as an unknown builtin.

### Description
- Replaced the unqualified call in `maps/MP/gametypes/_awe_mapvote.gsc` with the namespaced helper `maps\mp\gametypes\_awe::cvardef(...)` so the shared AWE cvar helper is resolved correctly.

### Testing
- Ran a repository-wide scan via a Python script to detect unqualified `cvardef(` uses in `.gsc` files and confirmed no remaining occurrences in files that don't define `cvardef` (scan returned `count 0`).
- Verified the change is staged/committed and `git show` reports the single-file update to `maps/MP/gametypes/_awe_mapvote.gsc`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3d064eae88329a3bfe22f15280d97)