### PR TITLE
Gate PAM SD spawn in toaxis/toallies and add non-SD fallback

### DIFF
--- a/_rPAM_rules/_rpam_admin.gsc
+++ b/_rPAM_rules/_rpam_admin.gsc
@@ -770,13 +770,24 @@ toaxis(all)
 		self setWeaponSlotWeapon("primary", "kar98k_mp");
 		self setWeaponSlotWeapon("primaryb", "mosin_nagant_mp");
 		self setClientCvar("g_scriptMainMenu", game["menu_weapon_" + team]);
-		self maps\mp\gametypes\_pam_sd::spawnPlayer();
+
+		if (gt == "sd")
+		{
+			iprintln(level._prefix + "^3[rPAM admin] toaxis respawn branch: sd");
+			self maps\mp\gametypes\_pam_sd::spawnPlayer();
+		}
+		else
+		{
+			iprintln(level._prefix + "^3[rPAM admin] toaxis respawn branch: non-sd");
+			self openMenu(game["menu_weapon_" + team]);
+		}
 	}
 	else if(getCvar("scr_force_bolt_rifles") == "0")
 	{
 		//self _rPAM_rules\_rpam_admin_utils::spawnSpectator();
 		self setClientCvar("ui_weapontab", "1");			// for uo
 		self setClientCvar("g_scriptMainMenu", game["menu_weapon_" + team]);
+		iprintln(level._prefix + "^3[rPAM admin] toaxis respawn branch: non-sd");
 		self openMenu(game["menu_weapon_" + team]);
 	}
 
@@ -852,12 +863,23 @@ toallies(all)
 		self setWeaponSlotWeapon("primary", "mosin_nagant_mp");
 		self setWeaponSlotWeapon("primaryb", "kar98k_mp");
 		self setClientCvar("g_scriptMainMenu", game["menu_weapon_" + team]);
-		self maps\mp\gametypes\_pam_sd::spawnPlayer();
+
+		if (gt == "sd")
+		{
+			iprintln(level._prefix + "^3[rPAM admin] toallies respawn branch: sd");
+			self maps\mp\gametypes\_pam_sd::spawnPlayer();
+		}
+		else
+		{
+			iprintln(level._prefix + "^3[rPAM admin] toallies respawn branch: non-sd");
+			self openMenu(game["menu_weapon_" + team]);
+		}
 	}
 	else if(getCvar("scr_force_bolt_rifles") == "0")
 	{
 		self setClientCvar("ui_weapontab", "1");			// for uo
 		self setClientCvar("g_scriptMainMenu", game["menu_weapon_" + team]);
+		iprintln(level._prefix + "^3[rPAM admin] toallies respawn branch: non-sd");
 		self openMenu(game["menu_weapon_" + team]);
 	}
 


### PR DESCRIPTION
### Motivation
- Prevent PAM SD-specific spawn code from being invoked when the current gametype is not `sd` to avoid crashes and incorrect respawn flow.
- Preserve the existing weapon menu setup and AWE-compatible menu-driven flow for non-SD gametypes instead of forcing `_pam_sd::spawnPlayer()`.
- Add a concise debug trace so it's easy to see which branch (`sd` vs `non-sd`) was taken during a team move for crash tracing.

### Description
- Updated `toaxis()` and `toallies()` in `_rPAM_rules/_rpam_admin.gsc` to conditionally call `maps\mp\gametypes\_pam_sd::spawnPlayer()` only when `g_gametype == "sd"` and otherwise use the existing menu flow (`g_scriptMainMenu` + `openMenu(...)`).
- Kept the weapon menu setup and bolt-rifle slot assignments in both branches so menu handling (`g_scriptMainMenu`) remains available for non-SD modes.
- Added debug `iprintln` lines that log which branch was taken for each function (`toaxis` and `toallies`) with the prefix `^3[rPAM admin] ... respawn branch: sd|non-sd` to aid crash tracing.

### Testing
- No automated tests were executed for this change (no test harness available for these game script files).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f40c75a18c8329a4aaa3874209637e)