### PR TITLE
Gate rPAM monitor to SD gametype and add idempotent startup guards

### DIFF
--- a/_rPAM_rules/_rpam_monitor.gsc
+++ b/_rPAM_rules/_rpam_monitor.gsc
@@ -3,15 +3,29 @@
 
 start()
 {
-	if (level._jumper) {
+	gametype = getdvar("g_gametype");
+	if (gametype != "sd") {
+		logprint("[rPAM] monitor startup skipped for non-SD gametype: " + gametype + "\n");
+		return;
+	}
+
+	if (isDefined(level._rpam_monitor_started) && level._rpam_monitor_started) {
+		return;
+	}
+	level._rpam_monitor_started = true;
+
+	if (level._jumper && (!isDefined(level._rpam_monitor_jumper_started) || !level._rpam_monitor_jumper_started)) {
+		level._rpam_monitor_jumper_started = true;
 		thread _rPAM_rules\monitor\jumper::start();
 	}
 	
-	if (level._afk_to_spec || level._fence) {
+	if ((level._afk_to_spec || level._fence) && (!isDefined(level._rpam_monitor_position_started) || !level._rpam_monitor_position_started)) {
+		level._rpam_monitor_position_started = true;
 		thread _rPAM_rules\monitor\position::start(level._afk_to_spec, level._fence);
 	}
 
-	if (level._anti_fastshoot || level._anti_aimrun) {
+	if ((level._anti_fastshoot || level._anti_aimrun) && (!isDefined(level._rpam_monitor_weapon_started) || !level._rpam_monitor_weapon_started)) {
+		level._rpam_monitor_weapon_started = true;
 		thread _rPAM_rules\monitor\weapon::start(level._anti_fastshoot, level._anti_aimrun);
 	}
 
@@ -23,7 +37,8 @@ start()
 //		thread _rPAM_rules\monitor\sprint::start(level._sprint, level._sprint_time, level._sprint_time_recover);
 //	}
 
-	if (level._allow_drop) {
+	if (level._allow_drop && (!isDefined(level._rpam_monitor_weapon_drop_started) || !level._rpam_monitor_weapon_drop_started)) {
+		level._rpam_monitor_weapon_drop_started = true;
 		thread _rPAM_rules\monitor\weapon_drop::start();
 	}
 }


### PR DESCRIPTION
### Motivation
- Prevent rPAM monitor threads from starting on unsupported gametypes and avoid duplicate monitor threads when a map reloads or `start()` is called multiple times.
- Make monitor startup explicit and observable by logging when initialization is skipped for non-`sd` gametypes.

### Description
- Read `g_gametype` at the top of `start()` and return early when it is not `"sd"`, logging the skipped startup with `logprint`.
- Add a map-level guard `level._rpam_monitor_started` to ensure the overall monitor initialization runs only once per map.
- Add per-monitor idempotent flags (`level._rpam_monitor_jumper_started`, `level._rpam_monitor_position_started`, `level._rpam_monitor_weapon_started`, `level._rpam_monitor_weapon_drop_started`) so each monitor thread is started at most once.
- Wrap existing monitor startup conditions to check and set the new flags before spawning monitor threads.

### Testing
- Inspected the resulting file with `nl -ba _rPAM_rules/_rpam_monitor.gsc` to verify the new logic and guards were inserted and formatted correctly, and this succeeded.
- Searched repository references with `rg` to confirm the target file and relevant symbols were present, and these searches succeeded.
- Reviewed the generated diff for correctness and syntax consistency, and no syntax errors were observed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f40d1ef3688329b37206ce8cd097ff)