### PR TITLE
Gate SD-only rPAM rules by gametype and add startup path logs

### DIFF
--- a/maps/MP/gametypes/_pam_sd.gsc
+++ b/maps/MP/gametypes/_pam_sd.gsc
@@ -151,8 +151,8 @@ PamMain()
 	if(getCvar("sv_messagecenter") == "")
 		setCvar("sv_messagecenter", "0");
 
-	if(getCvar("pam_mode") == "")
-		thread _rPAM_rules\_rPAM_rulesets_sd::rPAMMODEdefault();
+	initSharedPAMCvars();
+	initSdPAMRules();
 
 	if(!isdefined(game["runonce"]))
 	{
@@ -161,7 +161,8 @@ PamMain()
 		level.scorelimit = getCvarInt("scr_sd_scorelimit");
 		level.roundlimit = getCvarInt("scr_sd_roundlimit");
 
-		thread _rPAM_rules\_rPAM_rulesets_sd::rPAMMODES();
+		if (isSdGametype())
+			thread _rPAM_rules\_rPAM_rulesets_sd::rPAMMODES();
 
 		if(!isDefined(game["mode"]))
 			game["mode"] = "match";
@@ -459,6 +460,30 @@ PamMain()
 	if(level.killcam >= 1)
 		setarchive(true);
 	
+}
+
+isSdGametype()
+{
+	return getCvar("g_gametype") == "sd";
+}
+
+initSharedPAMCvars()
+{
+	if(getCvar("pam_mode") == "")
+		setCvar("pam_mode", "aw_mr12");
+}
+
+initSdPAMRules()
+{
+	if (isSdGametype())
+	{
+		iprintln("^3[rPAM]^7 " + level.mapname + ": PAM SD ruleset path selected (g_gametype=sd).");
+		thread _rPAM_rules\_rPAM_rulesets_sd::rPAMMODEdefault();
+	}
+	else
+	{
+		iprintln("^3[rPAM]^7 " + level.mapname + ": AWE/general path selected (g_gametype=" + getCvar("g_gametype") + "), skipping SD-only PAM rules.");
+	}
 }
 
 rRIFLEHITBLIP()
@@ -3401,6 +3426,13 @@ updateGametypeCvars()
 		league = getCvar("pam_mode");
 		if(league != level.league && !enabling)
 		{
+			if(!isSdGametype())
+			{
+				level.league = league;
+				wait .05;
+				continue;
+			}
+
 			ValidPamMode = _rPAM_rules\_rPAM_rulesets_sd::rCHECKPAMMODES(league);
 
 			if (ValidPamMode)

--- a/maps/MP/gametypes/_pam_sd_unmodified.gsc
+++ b/maps/MP/gametypes/_pam_sd_unmodified.gsc
@@ -151,8 +151,8 @@ PamMain()
 	if(getCvar("sv_messagecenter") == "")
 		setCvar("sv_messagecenter", "0");
 
-	if(getCvar("pam_mode") == "")
-		thread _rPAM_rules\_rPAM_rulesets_sd::rPAMMODEdefault();
+	initSharedPAMCvars();
+	initSdPAMRules();
 
 	if(!isdefined(game["runonce"]))
 	{
@@ -161,7 +161,8 @@ PamMain()
 		level.scorelimit = getCvarInt("scr_sd_scorelimit");
 		level.roundlimit = getCvarInt("scr_sd_roundlimit");
 
-		thread _rPAM_rules\_rPAM_rulesets_sd::rPAMMODES();
+		if (isSdGametype())
+			thread _rPAM_rules\_rPAM_rulesets_sd::rPAMMODES();
 
 		if(!isDefined(game["mode"]))
 			game["mode"] = "match";
@@ -459,6 +460,30 @@ PamMain()
 	if(level.killcam >= 1)
 		setarchive(true);
 	
+}
+
+isSdGametype()
+{
+	return getCvar("g_gametype") == "sd";
+}
+
+initSharedPAMCvars()
+{
+	if(getCvar("pam_mode") == "")
+		setCvar("pam_mode", "aw_mr12");
+}
+
+initSdPAMRules()
+{
+	if (isSdGametype())
+	{
+		iprintln("^3[rPAM]^7 " + level.mapname + ": PAM SD ruleset path selected (g_gametype=sd).");
+		thread _rPAM_rules\_rPAM_rulesets_sd::rPAMMODEdefault();
+	}
+	else
+	{
+		iprintln("^3[rPAM]^7 " + level.mapname + ": AWE/general path selected (g_gametype=" + getCvar("g_gametype") + "), skipping SD-only PAM rules.");
+	}
 }
 
 rRIFLEHITBLIP()
@@ -3273,6 +3298,13 @@ updateGametypeCvars()
 		league = getCvar("pam_mode");
 		if(league != level.league && !enabling)
 		{
+			if(!isSdGametype())
+			{
+				level.league = league;
+				wait .05;
+				continue;
+			}
+
 			ValidPamMode = _rPAM_rules\_rPAM_rulesets_sd::rCHECKPAMMODES(league);
 
 			if (ValidPamMode)


### PR DESCRIPTION
### Motivation
- Prevent SD-specific rules in `_rpam_rulesets_sd.gsc` from running on non-SD gametypes so PAM defaults are not overwritten by non-SD maps.
- Split shared cvar bootstrapping from SD-only ruleset mutation so safe global initialization can run on any map.
- Provide clear startup logs per map load indicating whether the PAM SD path or the AWE/general path was selected for easier debugging.

### Description
- Added a helper `isSdGametype()` that returns `getCvar("g_gametype") == "sd"` to centralize the SD check.
- Introduced `initSharedPAMCvars()` to perform shared/global PAM cvar initialization (defaults `pam_mode` to `"aw_mr12"` when empty) and `initSdPAMRules()` that logs the selected path and invokes `rPAMMODEdefault()` only when on an SD gametype.
- Guarded the `rPAMMODES()` call inside `PamMain()` with `if (isSdGametype())` and updated the `updateGametypeCvars()` loop to skip invoking `rCHECKPAMMODES()` on non-SD maps by assigning `level.league` and continuing, preventing non-SD maps from triggering SD-only validation/restarts.
- Mirrored the same changes into both `maps/MP/gametypes/_pam_sd.gsc` and `maps/MP/gametypes/_pam_sd_unmodified.gsc` and added `iprintln` startup messages showing the chosen path and current `g_gametype`.

### Testing
- Ran `rg -n "rPAMMODEdefault|rPAMMODES|rCHECKPAMMODES|initSdPAMRules|initSharedPAMCvars|isSdGametype"` to verify the new symbols and guarded calls are present, which succeeded.
- Inspected inserted sections and startup messages with `nl`/`sed` to confirm `initSharedPAMCvars()`, `initSdPAMRules()`, and `isSdGametype()` were added at the correct locations, which succeeded.
- Verified repository diffs and file-level changes to ensure only the two PAM SD gametype files were modified, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f40e8fa6c08329b2c23db9c5fabbed)