### PR TITLE
Add startup profile boundary between PAM SD and AWE gametypes

### DIFF
--- a/maps/MP/gametypes/_pam_sd.gsc
+++ b/maps/MP/gametypes/_pam_sd.gsc
@@ -151,6 +151,7 @@ PamMain()
 	if(getCvar("sv_messagecenter") == "")
 		setCvar("sv_messagecenter", "0");
 
+	ApplyStartupProfileBoundary();
 	initSharedPAMCvars();
 	initSdPAMRules();
 
@@ -465,6 +466,82 @@ PamMain()
 isSdGametype()
 {
 	return getCvar("g_gametype") == "sd";
+}
+
+ApplyStartupProfileBoundary()
+{
+	isSd = isSdGametype();
+	activeProfile = "awe";
+	oppositeProfile = "pam";
+
+	if (isSd)
+	{
+		activeProfile = "pam";
+		oppositeProfile = "awe";
+	}
+
+	ApplyOwnedProfileCvars(activeProfile);
+	if (getCvar("empire_last_profile") != activeProfile)
+		ResetOwnedProfileCvars(oppositeProfile);
+
+	setCvar("empire_last_profile", activeProfile);
+	LogEffectiveProfile(activeProfile);
+}
+
+ApplyOwnedProfileCvars(profile)
+{
+	// Shared ownership (PAM + AWE)
+	EnsureCvar("pam_mode", "aw_mr12");
+	EnsureCvar("sv_messagecenter", "0");
+	EnsureCvar("scr_friendlyfire", "1");
+
+	if (profile == "pam")
+	{
+		// PAM-only ownership
+		EnsureCvar("sv_pamenable", "1");
+		EnsureCvar("rpam_playersleft", "0");
+		EnsureCvar("rpam_streaming", "0");
+		EnsureCvar("sv_showstats", "1");
+		return;
+	}
+
+	// AWE-only ownership
+	EnsureCvar("sv_pamenable", "0");
+	EnsureCvar("awe_disablehud", "0");
+	EnsureCvar("awe_hudgun", "1");
+	EnsureCvar("awe_hudhealth", "1");
+}
+
+ResetOwnedProfileCvars(profile)
+{
+	if (profile == "pam")
+	{
+		// Reset PAM-only knobs to safe non-SD defaults
+		setCvar("rpam_playersleft", "0");
+		setCvar("rpam_streaming", "0");
+		setCvar("sv_showstats", "0");
+		return;
+	}
+
+	// Reset AWE-only knobs to safe SD/PAM defaults
+	setCvar("awe_disablehud", "0");
+	setCvar("awe_hudgun", "1");
+	setCvar("awe_hudhealth", "1");
+}
+
+LogEffectiveProfile(profile)
+{
+	gt = getCvar("g_gametype");
+	iprintln("^3[profile]^7 map init | gametype=" + gt + " | effective=" + profile);
+	iprintln("^3[profile]^7 shared: pam_mode=" + getCvar("pam_mode") + ", ff=" + getCvar("scr_friendlyfire") + ", msgcenter=" + getCvar("sv_messagecenter"));
+	iprintln("^3[profile]^7 pam: sv_pamenable=" + getCvar("sv_pamenable") + ", rpam_playersleft=" + getCvar("rpam_playersleft") + ", rpam_streaming=" + getCvar("rpam_streaming"));
+	iprintln("^3[profile]^7 awe: awe_disablehud=" + getCvar("awe_disablehud") + ", awe_hudgun=" + getCvar("awe_hudgun") + ", awe_hudhealth=" + getCvar("awe_hudhealth"));
+}
+
+EnsureCvar(name, value)
+{
+	if (getCvar(name) == "")
+		setCvar(name, value);
 }
 
 initSharedPAMCvars()


### PR DESCRIPTION
### Motivation
- Avoid conflicting cvar state when switching between SD (PAM) and non-SD (AWE) gametypes by establishing an ownership boundary.  
- Ensure only the active mod profile's cvars are applied at map start and that inactive-profile cvars are reset to safe defaults on profile changes.  
- Provide a compact, readable log of the effective profile and key cvars at map init to make debugging profile interactions easier.

### Description
- Call `ApplyStartupProfileBoundary()` during `PamMain()` before existing `initSharedPAMCvars()` / `initSdPAMRules()` to enforce profile boundary at startup in `maps/MP/gametypes/_pam_sd.gsc`.  
- Add `ApplyStartupProfileBoundary()`, `ApplyOwnedProfileCvars()`, `ResetOwnedProfileCvars()`, `LogEffectiveProfile()` and `EnsureCvar()` helper functions to select the active profile (SD => `pam`, otherwise `awe`) and apply/reset cvars accordingly.  
- Group cvars into `shared` (`pam_mode`, `sv_messagecenter`, `scr_friendlyfire`), `PAM-only` (`sv_pamenable`, `rpam_playersleft`, `rpam_streaming`, `sv_showstats`) and `AWE-only` (`awe_disablehud`, `awe_hudgun`, `awe_hudhealth`) ownership and apply defaults only for the owning profile.  
- Use `empire_last_profile` cvar to detect profile changes between map loads and perform explicit resets of the opposite profile when a switch is detected, and emit a compact effective-profile log line including `g_gametype` and the key cvars.

### Testing
- `apply_patch` successfully updated `maps/MP/gametypes/_pam_sd.gsc` (patch applied).  
- `git add` / `git commit` succeeded with message `Add gametype profile boundary for PAM/AWE cvars`.  
- Repository inspections (`rg` / `sed` / `nl`) were run to verify insertion locations and function definitions and completed successfully; no automated runtime tests were executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f40f6fea2083299f6daf6f6b4f33da)